### PR TITLE
Fixed bug preventing click event from firing

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,8 +295,8 @@ module.exports = class Input extends EventEmitter
         }
         const x = window.navigator.msPointerEnabled ? e.offsetX : e.clientX
         const y = window.navigator.msPointerEnabled ? e.offsetY : e.clientY
-        this.pointers.pop()
         this.handleUp(x, y, e, 'mouse')
+        this.pointers.pop()
     }
 
     handleDown(x, y, e, id)


### PR DESCRIPTION
Moved pointer pop to after the event handler so clicks are actually propagated.

in handleUp, there is a check for pointers.length to equal one. If the pointers are removed before that even, then it will always be an empty array in the case of a mouse click